### PR TITLE
Add window.disqus_config to implement properly initialized

### DIFF
--- a/vue-disqus.js
+++ b/vue-disqus.js
@@ -26,16 +26,20 @@ Vue.component('disqus', {
     },
     init: function () {
       var self = this
+      window.disqus_config = function() {
+        this.page.url = (self.$route.path || window.location.pathname)
+        this.page.url = self.$el.baseURI
+      }
       setTimeout(function () {
-        (function () {
-          var dsq = document.createElement('script')
-          dsq.type = 'text/javascript'
-          dsq.async = true
-          dsq.setAttribute('id', 'embed-disqus')
-          dsq.src = 'http://' + self.shortname + '.disqus.com/embed.js'
-          document.getElementsByTagName('body')[0].appendChild(dsq)
-        })()
-      }, 100)
+        var d = document
+          , s = d.createElement('script')
+        s.setAttribute('id', 'embed-disqus')
+        s.setAttribute('data-timestamp', +new Date())
+        s.type = 'text/javascript'
+        s.async = true
+        s.src = '//' + self.shortname + '.disqus.com/embed.js'
+        ;(d.head || d.body).appendChild(s)
+      }, 0)
     }
   }
 });

--- a/vue-disqus.vue
+++ b/vue-disqus.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="disqus_thread"></div> 
+  <div id="disqus_thread"></div>
 </template>
 
 <script>
@@ -29,16 +29,21 @@
         })
       },
       init () {
+        const self = this
+        window.disqus_config = function() {
+          this.page.url = (self.$route.path || window.location.pathname)
+          this.page.url = self.$el.baseURI
+        }
         setTimeout(() => {
-          (() => {
-            let dsq = document.createElement('script')
-            dsq.type = 'text/javascript'
-            dsq.async = true
-            dsq.setAttribute('id', 'embed-disqus')
-            dsq.src = 'http://' + this.shortname + '.disqus.com/embed.js'
-            document.getElementsByTagName('body')[0].appendChild(dsq)
-          })()
-        }, 100)
+          let d = document
+            , s = d.createElement('script')
+          s.type = 'text/javascript'
+          s.async = true
+          s.setAttribute('id', 'embed-disqus')
+          s.setAttribute('data-timestamp', +new Date())
+          s.src = `//${this.shortname}.disqus.com/embed.js`
+          ;(d.head || d.body).appendChild(s)
+        }, 0)
       }
     }
   }


### PR DESCRIPTION
If not window.disqus_config, Disqus will be possible bind to the wrong url and identifier when SPA init.