### PR TITLE
Add umd to umd

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ npm install vue-disqus
 > For Vue 1.* use [v1.0.2](https://github.com/ktquez/vue-disqus/tree/v1.0.2) - `npm install --save vue-disqus@1.0.2` 
 
 ## Using in `.vue` files
-##### 2.) Add the component disqus
+##### 2.) Add the component `vue-disqus`
 ```javascript
 <template>
   // omited
@@ -23,12 +23,12 @@ $ npm install vue-disqus
 </template>
 
 <script>
-import Disqus from 'vue-disqus'
+import VueDisqus from 'vue-disqus'
 
 export default {
   // ...
   components: {
-    Disqus
+    VueDisqus
   }
 }
 // ...
@@ -36,8 +36,15 @@ export default {
 
 ---
 
+## Using in AMD or CommonJS modules
+##### 3.) require the component `vue-disqus`
+
+var VueDisqus = require('vue-disqus')
+
+---
+
 ## Using with HTML files
-##### 3.) Add the component to the base instance Vue
+##### 4.) Add the component to the base instance Vue
 
 ```html
 <!-- Required Javascript -->
@@ -49,7 +56,7 @@ export default {
 <!-- Assuming your view app is APP. -->
 <body id="app">
   <div class="comments">
-    <disqus shortname="your_shortname_disqus"></disqus>
+    <vue-disqus shortname="your_shortname_disqus"></vue-disqus>
   </div>
 </body>
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install vue-disqus
 </template>
 
 <script>
-import VueDisqus from 'vue-disqus'
+import VueDisqus from 'vue-disqus/VueDisqus.vue'
 
 export default {
   // ...

--- a/VueDisqus.vue
+++ b/VueDisqus.vue
@@ -4,6 +4,7 @@
 
 <script>
   export default {
+    name: 'vue-disqus',
     props: {
       shortname: {
         type: String,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-disqus",
   "version": "2.0.0",
   "description": "Vue component to integrate Disqus comments in your application, with support for SPA",
-  "main": "vue-disqus.vue",
+  "main": "vue-disqus.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/vue-disqus.js
+++ b/vue-disqus.js
@@ -1,45 +1,61 @@
-Vue.component('disqus', {
-  template: '<div id="disqus_thread"></div>',
-  props: {
-    shortname: {
-      type: String,
-      required: true
-    }
-  },
-  mounted: function () {
-    if (window.DISQUS) {
-      this.reset(window.DISQUS)
-      return
-    }
-    this.init()
-  },
-  methods: {
-    reset: function (dsq) {
-      var self = this
-      dsq.reset({
-        reload: true,
-        config: function () {
-          this.page.identifier = (self.$route.path || window.location.pathname)
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // amd
+    define('VueDisqus', ['vue'], factory);
+  } else if (typeof exports === 'object' && typeof module === 'object') {
+    // commonjs2
+    module.exports = factory(require('vue'));
+  } else if (typeof exports === 'object') {
+    // commonjs
+    exports.VueDisqus = factory(require('vue'));
+  } else {
+    // global variable
+    root.VueDisqus = factory(root.Vue);
+  }
+})(this, function (Vue) {
+  return Vue.component('vue-disqus', {
+    template: '<div id="disqus_thread"></div>',
+    props: {
+      shortname: {
+        type: String,
+        required: true
+      }
+    },
+    mounted: function () {
+      if (window.DISQUS) {
+        this.reset(window.DISQUS)
+        return
+      }
+      this.init()
+    },
+    methods: {
+      reset: function (dsq) {
+        var self = this
+        dsq.reset({
+          reload: true,
+          config: function () {
+            this.page.identifier = (self.$route.path || window.location.pathname)
+            this.page.url = self.$el.baseURI
+          }
+        })
+      },
+      init: function () {
+        var self = this
+        window.disqus_config = function() {
+          this.page.url = (self.$route.path || window.location.pathname)
           this.page.url = self.$el.baseURI
         }
-      })
-    },
-    init: function () {
-      var self = this
-      window.disqus_config = function() {
-        this.page.url = (self.$route.path || window.location.pathname)
-        this.page.url = self.$el.baseURI
+        setTimeout(function () {
+          var d = document
+            , s = d.createElement('script')
+          s.setAttribute('id', 'embed-disqus')
+          s.setAttribute('data-timestamp', +new Date())
+          s.type = 'text/javascript'
+          s.async = true
+          s.src = '//' + self.shortname + '.disqus.com/embed.js'
+          ;(d.head || d.body).appendChild(s)
+        }, 0)
       }
-      setTimeout(function () {
-        var d = document
-          , s = d.createElement('script')
-        s.setAttribute('id', 'embed-disqus')
-        s.setAttribute('data-timestamp', +new Date())
-        s.type = 'text/javascript'
-        s.async = true
-        s.src = '//' + self.shortname + '.disqus.com/embed.js'
-        ;(d.head || d.body).appendChild(s)
-      }, 0)
     }
-  }
+  });
 });


### PR DESCRIPTION
The major change is in **vue-disqus.js**. With umd support, the component is adaptive to more use cases.

There are some breaking changes though:

1. Since it's umd ready, the `main` field in **package.json** is pointed to the JS file now. This favors people that don't use webpack or browserify in their projects.

2. As Disqus has occupied the namespace `DISQUS`, for concerns of clearness, the component's name is altered to `vue-disqus` (was `disqus`), and the global variable is `VueDisqus`. The changes has been reflected in the README.