### PR TITLE
Add `language` option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,15 @@ Prop            | Data Type  | required  | Description
 `shortname`     | String     | true      | Your shortname disqus.
 `title`         | String     | false     | Title to identify current page.
 `identifier`    | String     | false     | Your unique identifier
-`sso_config`    | Object     | false     | Single sign-on (SSO) 
+`sso_config`    | Object     | false     | Single sign-on (SSO)
 `api_key`       | String     | false     | Your API key disqus
 `remote_auth_s3`| String     | false     | implementation with Laravel/PHP
+`language`      | String     | false     | Language overrides
 
 ## Events
 
-Event name | Description 
----------- | ----------- 
+Event name | Description
+---------- | -----------
 `ready`    | When Disqus is ready. This can be used to show a placeholder or loading indicator.
 
 

--- a/VueDisqus.vue
+++ b/VueDisqus.vue
@@ -33,6 +33,10 @@
       sso_config: {
         type: Object,
         required: false
+      },
+      language: {
+        type: String,
+        required: false
       }
     },
     mounted () {
@@ -82,6 +86,9 @@
         }
         if (this.sso_config){
           disqusConfig.sso = this.sso_config;
+        }
+        if (this.language){
+          disqusConfig.language = this.language;
         }
 
         disqusConfig.callbacks.onReady = [() => {

--- a/vue-disqus.js
+++ b/vue-disqus.js
@@ -43,6 +43,10 @@
       sso_config: {
         type: Object,
         required: false
+      },
+      language: {
+        type: String,
+        required: false
       }
     },
     mounted: function () {
@@ -93,7 +97,9 @@
         if (this.sso_config){
           disqusConfig.sso = this.sso_config;
         }
-
+        if (this.language){
+          disqusConfig.language = this.language;
+        }
         disqusConfig.callbacks.onReady = [() => {
           this.$emit('ready')
         }]


### PR DESCRIPTION
Implemented the API defined in this document.

https://help.disqus.com/installation/multi-lingual-websites