### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 $ npm install vue-disqus
 ```
 
+#### Include via CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/vue-disqus@3/dist/vue-disqus.js"></script>
+```
+
 #### Install in your vue app
 ```javascript
 import Vue from 'vue'


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/vue-disqus) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.