### PR TITLE
Emit event on onNewComment callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ Don't use hash (`myurl.com/#/`) in urls, if you are using the vue-router always 
 
 ## Events
 
-Event name | Description
----------- | -----------
-`ready`    | When Disqus is ready. This can be used to show a placeholder or loading indicator.
+Event name    | Description
+------------- | -----------
+`ready`       | When Disqus is ready. This can be used to show a placeholder or loading indicator.
+`new-comment` | When a new comment is posted. This can be used to update comment counters in real time.
 
 
 See [Event Handling](https://vuejs.org/v2/guide/events.html).

--- a/dist/vue-disqus.vue
+++ b/dist/vue-disqus.vue
@@ -95,8 +95,8 @@
           this.$emit('ready')
         }]
         
-        disqusConfig.callbacks.onNewComment = [() => {
-          this.$emit('new-comment')
+        disqusConfig.callbacks.onNewComment = [(comment) => {
+          this.$emit('new-comment', comment)
         }]
       }
     }

--- a/dist/vue-disqus.vue
+++ b/dist/vue-disqus.vue
@@ -94,6 +94,10 @@
         disqusConfig.callbacks.onReady = [() => {
           this.$emit('ready')
         }]
+        
+        disqusConfig.callbacks.onNewComment = [() => {
+          this.$emit('new-comment')
+        }]
       }
     }
   }

--- a/src/vue-disqus.vue
+++ b/src/vue-disqus.vue
@@ -95,8 +95,8 @@
           this.$emit('ready')
         }]
         
-        disqusConfig.callbacks.onNewComment = [() => {
-          this.$emit('new-comment')
+        disqusConfig.callbacks.onNewComment = [(comment) => {
+          this.$emit('new-comment', comment)
         }]
       }
     }

--- a/src/vue-disqus.vue
+++ b/src/vue-disqus.vue
@@ -94,6 +94,10 @@
         disqusConfig.callbacks.onReady = [() => {
           this.$emit('ready')
         }]
+        
+        disqusConfig.callbacks.onNewComment = [() => {
+          this.$emit('new-comment')
+        }]
       }
     }
   }


### PR DESCRIPTION
I added a handler for Disqus' onNewComment callback which emits a Vue event named 'new-comment' with a _comment_ parameter passed into an event handler.